### PR TITLE
Infrastructure-As-Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # codehub-terraform
 Contains Terraform templates for infrastructure-as-code.
+
+# Usage
+
+Run `apply.sh` to create the infrastructure.
+
+Run `destroy.sh` to destroy the infrastructure.
+
+# TODO
+
+[ ] Implement environment variables
+[ ] Modularize and reuse code

--- a/api.tf
+++ b/api.tf
@@ -1,0 +1,82 @@
+locals {
+  api_security_groups = ["sg-07c4054e6ca310400"]
+  api_port            = 3000
+  api_image           = "797335914619.dkr.ecr.us-east-1.amazonaws.com/dev-codehub/codehub-api:latest"
+}
+
+resource "aws_lb" "codehub_prod_api_lb" {
+  name               = "codehub-prod-api-lb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = "${local.api_security_groups}"
+  subnets            = "${local.prod_private_subnets}"
+}
+
+resource "aws_lb_listener" "codehub_prod_api_lb_listener" {
+  load_balancer_arn = "${aws_lb.codehub_prod_api_lb.arn}"
+  port              = "${local.api_port}"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.codehub_prod_api_tg_1.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "codehub_prod_api_tg_1" {
+  name        = "codehub-prod-api-tg-1"
+  port        = "${local.api_port}"
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${local.prod_vpc_id}"
+  depends_on  = ["aws_lb.codehub_prod_api_lb"]
+}
+
+resource "aws_ecs_task_definition" "codehub_prod_api_taskdef" {
+  family                = "codehub-prod-api-taskdef"
+  container_definitions = <<EOF
+    [
+      {
+        "name": "codehub-prod-api",
+        "image": "${local.api_image}",
+        "cpu": 256,
+        "memory": 512,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": ${local.api_port},
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ]
+    EOF
+
+  task_role_arn            = "${local.prod_task_role_arn}"
+  execution_role_arn       = "${local.prod_execution_role_arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "codehub_prod_api" {
+  name            = "codehub-prod-api"
+  cluster         = "${aws_ecs_cluster.codehub_prod_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.codehub_prod_api_taskdef.arn}"
+  desired_count   = 1
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.codehub_prod_api_tg_1.arn}"
+    container_name   = "codehub-prod-api"
+    container_port   = "${local.api_port}"
+  }
+
+  network_configuration {
+    security_groups = "${local.api_security_groups}"
+    subnets         = "${local.prod_private_subnets}"
+  }
+}
+

--- a/apply.sh
+++ b/apply.sh
@@ -1,0 +1,1 @@
+terraform apply --auto-approve

--- a/destroy.sh
+++ b/destroy.sh
@@ -1,0 +1,1 @@
+terraform destroy --auto-approve

--- a/kindred.tf
+++ b/kindred.tf
@@ -1,0 +1,82 @@
+locals {
+  kindred_security_groups = ["sg-0cb726a88410cb227"]
+  kindred_port            = 8082
+  kindred_image           = "797335914619.dkr.ecr.us-east-1.amazonaws.com/codehub-kindred:09f48b9"
+}
+
+resource "aws_lb" "codehub_prod_kindred_lb" {
+  name               = "codehub-prod-kindred-lb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = "${local.kindred_security_groups}"
+  subnets            = "${local.prod_private_subnets}"
+}
+
+resource "aws_lb_listener" "codehub_prod_kindred_lb_listener" {
+  load_balancer_arn = "${aws_lb.codehub_prod_kindred_lb.arn}"
+  port              = "${local.kindred_port}"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.codehub_prod_kindred_tg_1.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "codehub_prod_kindred_tg_1" {
+  name        = "codehub-prod-kindred-tg-1"
+  port        = "${local.kindred_port}"
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${local.prod_vpc_id}"
+  depends_on  = ["aws_lb.codehub_prod_kindred_lb"]
+}
+
+resource "aws_ecs_task_definition" "codehub_prod_kindred_taskdef" {
+  family                = "codehub-prod-kindred-taskdef"
+  container_definitions = <<EOF
+    [
+      {
+        "name": "codehub-prod-kindred",
+        "image": "${local.kindred_image}",
+        "cpu": 256,
+        "memory": 512,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": ${local.kindred_port},
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ]
+    EOF
+
+  task_role_arn            = "${local.prod_task_role_arn}"
+  execution_role_arn       = "${local.prod_execution_role_arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "codehub_prod_kindred" {
+  name            = "codehub-prod-kindred"
+  cluster         = "${aws_ecs_cluster.codehub_prod_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.codehub_prod_kindred_taskdef.arn}"
+  desired_count   = 1
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.codehub_prod_kindred_tg_1.arn}"
+    container_name   = "codehub-prod-kindred"
+    container_port   = "${local.kindred_port}"
+  }
+
+  network_configuration {
+    security_groups = "${local.kindred_security_groups}"
+    subnets         = "${local.prod_private_subnets}"
+  }
+}
+

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,17 @@
+############################
+### Global Configuration ###
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_ecs_cluster" "codehub_prod_cluster" {
+  name = "codehub-prod-cluster"
+}
+
+locals {
+  prod_private_subnets    = ["subnet-0eb0727ca38b96d02", "subnet-005743ce787e8baee", "subnet-0c568259d248437e5", "subnet-0c88df334bec87921", "subnet-05849499a2a28b0df", "subnet-05106e617d70bbe7b"]
+  prod_vpc_id             = "vpc-0384dfcb3a1d6b9e6"
+  prod_task_role_arn      = "arn:aws:iam::797335914619:role/BAHServiceRoleForECS"
+  prod_execution_role_arn = "arn:aws:iam::797335914619:role/BAHServiceRoleForECSTaskExecution"
+}

--- a/mongo.tf
+++ b/mongo.tf
@@ -1,0 +1,82 @@
+locals {
+  mongo_security_groups = ["sg-08fabf4b8e245f97d"]
+  mongo_port            = 27017
+  mongo_image           = "797335914619.dkr.ecr.us-east-1.amazonaws.com/codehub-mongo:600d7f1"
+}
+
+resource "aws_lb" "codehub_prod_mongo_lb" {
+  name               = "codehub-prod-mongo-lb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = "${local.mongo_security_groups}"
+  subnets            = "${local.prod_private_subnets}"
+}
+
+resource "aws_lb_listener" "codehub_prod_mongo_lb_listener" {
+  load_balancer_arn = "${aws_lb.codehub_prod_mongo_lb.arn}"
+  port              = "${local.mongo_port}"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.codehub_prod_mongo_tg_1.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "codehub_prod_mongo_tg_1" {
+  name        = "codehub-prod-mongo-tg-1"
+  port        = "${local.mongo_port}"
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${local.prod_vpc_id}"
+  depends_on  = ["aws_lb.codehub_prod_mongo_lb"]
+}
+
+resource "aws_ecs_task_definition" "codehub_prod_mongo_taskdef" {
+  family                = "codehub-prod-mongo-taskdef"
+  container_definitions = <<EOF
+    [
+      {
+        "name": "codehub-prod-mongo",
+        "image": "${local.mongo_image}",
+        "cpu": 256,
+        "memory": 512,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": ${local.mongo_port},
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ]
+    EOF
+
+  task_role_arn            = "${local.prod_task_role_arn}"
+  execution_role_arn       = "${local.prod_execution_role_arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "codehub_prod_mongo" {
+  name            = "codehub-prod-mongo"
+  cluster         = "${aws_ecs_cluster.codehub_prod_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.codehub_prod_mongo_taskdef.arn}"
+  desired_count   = 1
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.codehub_prod_mongo_tg_1.arn}"
+    container_name   = "codehub-prod-mongo"
+    container_port   = "${local.mongo_port}"
+  }
+
+  network_configuration {
+    security_groups = "${local.mongo_security_groups}"
+    subnets         = "${local.prod_private_subnets}"
+  }
+}
+

--- a/search.tf
+++ b/search.tf
@@ -1,0 +1,82 @@
+locals {
+  search_security_groups = ["sg-00546d6e3e8efe42d"]
+  search_port            = 9200
+  search_image           = "797335914619.dkr.ecr.us-east-1.amazonaws.com/dev-codehub/codehub-search:latest"
+}
+
+resource "aws_lb" "codehub_prod_search_lb" {
+  name               = "codehub-prod-search-lb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = "${local.search_security_groups}"
+  subnets            = "${local.prod_private_subnets}"
+}
+
+resource "aws_lb_listener" "codehub_prod_search_lb_listener" {
+  load_balancer_arn = "${aws_lb.codehub_prod_search_lb.arn}"
+  port              = "${local.search_port}"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.codehub_prod_search_tg_1.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "codehub_prod_search_tg_1" {
+  name        = "codehub-prod-search-tg-1"
+  port        = "${local.search_port}"
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${local.prod_vpc_id}"
+  depends_on  = ["aws_lb.codehub_prod_search_lb"]
+}
+
+resource "aws_ecs_task_definition" "codehub_prod_search_taskdef" {
+  family                = "codehub-prod-search-taskdef"
+  container_definitions = <<EOF
+    [
+      {
+        "name": "codehub-prod-search",
+        "image": "${local.search_image}",
+        "cpu": 256,
+        "memory": 512,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": ${local.search_port},
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ]
+    EOF
+
+  task_role_arn            = "${local.prod_task_role_arn}"
+  execution_role_arn       = "${local.prod_execution_role_arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "codehub_prod_search" {
+  name            = "codehub-prod-search"
+  cluster         = "${aws_ecs_cluster.codehub_prod_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.codehub_prod_search_taskdef.arn}"
+  desired_count   = 1
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.codehub_prod_search_tg_1.arn}"
+    container_name   = "codehub-prod-search"
+    container_port   = "${local.search_port}"
+  }
+
+  network_configuration {
+    security_groups = "${local.search_security_groups}"
+    subnets         = "${local.prod_private_subnets}"
+  }
+}
+

--- a/ui.tf
+++ b/ui.tf
@@ -1,0 +1,82 @@
+locals {
+  ui_security_groups = ["sg-05c26dc635daecd3a"]
+  ui_port            = 80
+  ui_image           = "797335914619.dkr.ecr.us-east-1.amazonaws.com/dev-codehub/codehub-ui:latest"
+}
+
+resource "aws_lb" "codehub_prod_ui_lb" {
+  name               = "codehub-prod-ui-lb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = "${local.ui_security_groups}"
+  subnets            = "${local.prod_private_subnets}"
+}
+
+resource "aws_lb_listener" "codehub_prod_ui_lb_listener" {
+  load_balancer_arn = "${aws_lb.codehub_prod_ui_lb.arn}"
+  port              = "${local.ui_port}"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.codehub_prod_ui_tg_1.arn}"
+  }
+}
+
+resource "aws_lb_target_group" "codehub_prod_ui_tg_1" {
+  name        = "codehub-prod-ui-tg-1"
+  port        = "${local.ui_port}"
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = "${local.prod_vpc_id}"
+  depends_on  = ["aws_lb.codehub_prod_ui_lb"]
+}
+
+resource "aws_ecs_task_definition" "codehub_prod_ui_taskdef" {
+  family                = "codehub-prod-ui-taskdef"
+  container_definitions = <<EOF
+    [
+      {
+        "name": "codehub-prod-ui",
+        "image": "${local.ui_image}",
+        "cpu": 256,
+        "memory": 512,
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": ${local.ui_port},
+            "protocol": "tcp"
+          }
+        ]
+      }
+    ]
+    EOF
+
+  task_role_arn            = "${local.prod_task_role_arn}"
+  execution_role_arn       = "${local.prod_execution_role_arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "codehub_prod_ui" {
+  name            = "codehub-prod-ui"
+  cluster         = "${aws_ecs_cluster.codehub_prod_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.codehub_prod_ui_taskdef.arn}"
+  desired_count   = 1
+
+  launch_type = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.codehub_prod_ui_tg_1.arn}"
+    container_name   = "codehub-prod-ui"
+    container_port   = "${local.ui_port}"
+  }
+
+  network_configuration {
+    security_groups = "${local.ui_security_groups}"
+    subnets         = "${local.prod_private_subnets}"
+  }
+}
+


### PR DESCRIPTION
This adds the first round of Terraform scripts.

Running `apply.sh` creates a full deployment. Then `destroy.sh` removes it all.

Note that parametrization of the routes is still TBD. The best way to do this would be to allow datasources.json (and similar hardcoded files) to use environment variables.